### PR TITLE
Updating spacing to have important info on front

### DIFF
--- a/_posts/2022-05-26-back-but-ocp-prod.md
+++ b/_posts/2022-05-26-back-but-ocp-prod.md
@@ -5,8 +5,7 @@ severity: 1
 ---
 
 The Mass Open Cloud services are available for use with one exception:
-
-- We are working on getting the ocp-prod cluster back up. We currently do not
+We are working on getting the ocp-prod cluster back up. We currently do not
 have a time frame. We will update this page as we gather more information.
 
 Thank you for your patience. This annual power-down helps MGHPCC to perform


### PR DESCRIPTION
Updated 2022-05-26-back-but-ocp-prod.md to ensure the
first few lines show up on the front page of the status
page so that the information displays fully.