### PR TITLE
Updating back but ocp prod

### DIFF
--- a/_posts/2022-05-26-back-but-ocp-prod.md
+++ b/_posts/2022-05-26-back-but-ocp-prod.md
@@ -1,11 +1,10 @@
 ---
 title: MOC Services Available for Use Except ocp-prod Cluster
-state: active
-severity: 1
+severity: 0
 ---
 
 The Mass Open Cloud services are available for use with one exception:
-We are working on getting the ocp-prod cluster back up. We currently do not
+- We are working on getting the ocp-prod cluster back up. We currently do not
 have a time frame. We will update this page as we gather more information.
 
 Thank you for your patience. This annual power-down helps MGHPCC to perform

--- a/_posts/2022-05-31-back-but-small-issues.md
+++ b/_posts/2022-05-31-back-but-small-issues.md
@@ -1,0 +1,11 @@
+---
+title: MOC Services Available for Use Except ocp-prod Cluster
+state: active
+severity: 1
+---
+
+We are continuing to investigate some issues with the `ocp-prod` OpenShift
+cluster. If you encounter any unexpected behavior, please contact us
+via our [helpdesk][].
+
+[helpdesk]: https://osticket.massopen.cloud/


### PR DESCRIPTION
Update 2022-05-26-back-but-ocp-prod.md to have the severity
of 0 and no longer active since ocp-prod is back up. Also added
a bullet to make it look better.
Created 2022-05-31-back-but-small-issues.md to track small
issues we are having with OpenShift