### PR TITLE
Update to remove active status from recent post

### DIFF
--- a/_posts/2022-05-31-back-but-small-issues.md
+++ b/_posts/2022-05-31-back-but-small-issues.md
@@ -1,11 +1,10 @@
 ---
-title: MOC Services Available for Use Except ocp-prod Cluster
-state: active
+title: MOC Services Available for Use, Still Investigating ocp-prod Cluster
 severity: 1
 ---
 
-We are continuing to investigate some issues with the `ocp-prod` OpenShift
-cluster. If you encounter any unexpected behavior, please contact us
+We are continuing to investigate some minor issues with the `ocp-prod`
+OpenShift cluster. If you encounter any unexpected behavior, please contact us
 via our [helpdesk][].
 
 [helpdesk]: https://osticket.massopen.cloud/


### PR DESCRIPTION
All customer-facing `ocp-prod` issues have been resolved so we no
longer need to have this post active.
Made a small change to the subject so that if we copy this
post in the future the title is more accurate.
Made a small grammatical change to the text to make it more
closely match the email sent out.