### PR TITLE
ocp-prod network maintenance and template typo fix

### DIFF
--- a/_posts/2022-09-19-ocp-prod-network-maintenance.md
+++ b/_posts/2022-09-19-ocp-prod-network-maintenance.md
@@ -1,0 +1,14 @@
+---
+title: ocp-prod Cluster Network Maintenance
+severity: 0
+state: active
+---
+
+September 26th the ocp-prod (OpenShift 4.x cluster) will be offline due to
+network maintenance. During this time ocp-prod will be unreachable.
+
+Thank you for your understanding and patience as we replace the switches for
+this network.
+
+Thanks
+MOC Alliance Staff

--- a/_posts/template.md
+++ b/_posts/template.md
@@ -3,7 +3,7 @@ title: Put title here
 state: active
 # Severity: 0=All systems are operating normally.
 # 1 = There are one or more service interruptions.
-# 3 or more = There is a critical service outage.
+# 2 or more = There is a critical service outage.
 severity: 0
 
 # Prevent template from getting published. Remove this


### PR DESCRIPTION
engage1 is moving public networks to a new network as old network switches are having problems. letting the openshift clients know.
communication for ops-issues number 661.
fix template typo