### PR TITLE
Change support email outgoing and disable old post

### DIFF
--- a/_posts/2022-09-19-ocp-prod-network-maintenance.md
+++ b/_posts/2022-09-19-ocp-prod-network-maintenance.md
@@ -1,7 +1,6 @@
 ---
 title: ocp-prod Cluster Network Maintenance
 severity: 1
-state: active
 ---
 
 September 27th & 28th the ocp-prod (OpenShift 4.x cluster) will be offline due

--- a/_posts/2023-03-06-support-outgoing-email-change.md
+++ b/_posts/2023-03-06-support-outgoing-email-change.md
@@ -1,0 +1,16 @@
+---
+title: Outgoing Support Email Change
+state: active
+severity: 0
+---
+The old support email address osticket@massopen.cloud has been replaced with
+support@moc.supportsystem.com and noreply@moc.supportsystem.com. Please check
+your email accounts to ensure that your spam filter will not block
+support@moc.supportsystem.com and noreply@moc.supportsystem.com
+
+If you have any additional questions, please create a ticket [here][1].
+
+Thanks
+MOC Staff
+
+[1]:https://osticket.massopen.cloud/login.php


### PR DESCRIPTION
email changed to resolve "unauthenticated email from
massopen.cloud is not accepted due to domain's
dmarc policy." and deactivate an old post that should
have been deactivated in october.