### PR TITLE
removing active status from os cluster updates

### DIFF
--- a/_posts/2022-02-10-openshift-updates.md
+++ b/_posts/2022-02-10-openshift-updates.md
@@ -1,6 +1,5 @@
 ---
 title: OpenShift Cluster Update Schedule
-state: active
 severity: 0
 ---
 OpenShift cluster `ocp-prod` will now be updated every first and third Monday of every month at 10:00 AM.


### PR DESCRIPTION
we no longer have an moc openshift therefore we
are not doing cluster updates